### PR TITLE
Readmeのコードブロックに言語識別子を指定

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ INIAD APIの非公式Node.jsクライアントライブラリです。
 
 npmを使用して簡単にインストールできます。
 
-```
+```sh
 npm install iniad-api-node
 ```
 
@@ -30,7 +30,7 @@ npm install iniad-api-node
 
 以下はES Modulesを使用した例です。
 
-```
+```typescript
 import { EduIotApiClient } from 'iniad-api-node';
 const iotClient = new EduIotApiClient(baseUrl, userId, password);
 


### PR DESCRIPTION
## 概要

Readmeのコードブロックにシンタックスハイライトが効いていなかったので言語識別子を追加して効くようにしました。

## 比較

### 変更前

![1713415513](https://github.com/imoken777/iniad-api-node/assets/131662659/fbe9857c-e342-42ab-99eb-a136d6619df7)

### 変更後

![1713415533](https://github.com/imoken777/iniad-api-node/assets/131662659/8b7a03f4-787d-4c24-ace4-427e96b1111b)
